### PR TITLE
Don't set value of radio buttons

### DIFF
--- a/index.esm.js
+++ b/index.esm.js
@@ -50,7 +50,7 @@ function registerField (state, field) {
             // update value
             if (field.type === 'checkbox') {
                 field.checked = value;
-            } else {
+            } else if (field.type !== 'radio') {
                 field.value = value === undefined ? '' : value;
             }
 

--- a/index.umd.js
+++ b/index.umd.js
@@ -54,7 +54,7 @@
                 // update value
                 if (field.type === 'checkbox') {
                     field.checked = value;
-                } else {
+                } else if (field.type !== 'radio') {
                     field.value = value === undefined ? '' : value;
                 }
 

--- a/lib/registerField.js
+++ b/lib/registerField.js
@@ -48,7 +48,7 @@ export default function (state, field) {
             // update value
             if (field.type === 'checkbox') {
                 field.checked = value;
-            } else {
+            } else if (field.type !== 'radio') {
                 field.value = value === undefined ? '' : value;
             }
 


### PR DESCRIPTION
Not sure what the intention of setting value here is, but for radio buttons, it will initially overwrite all of the initial values, and then after you click one radio button, it will overwrite the value of every radio button with that option, meaning your selection appears to change visibly but is actually locked to the first value you clicked. Adding this condition fixed this, at least for the 2 places in our client side code where there were radio buttons in riot-final-form